### PR TITLE
Fix file setting issue

### DIFF
--- a/transfers_files.html
+++ b/transfers_files.html
@@ -113,31 +113,30 @@
             </tr>
         </table>
 
+        <table class="xferstable ui sortable table" id="files-table">
+            <thead>
+            <tr>
+                <th>&nbsp;</th>
+                <th>Name</th>
+                <th>Priority</th>
+                <th>Bytes</th>
+                <th>Status</th>
+            </tr>
+            </thead>
+            <tbody>
+            <!--list_start files-->
+            <tr class="$statusclass_alt$">
+                <td><input class="selection" type="checkbox" name="$guid$" value="1" onclick="udctrls()"/></td>
+                <td>$name$</td>
+                <td>$priority$</td>
+                <td>$bytes$</td>
+                <td>$status$</td>
+            </tr>
+            <!--list_end-->
+            </tbody>
+        </table>
+
     </form>
-
-
-    <table class="xferstable ui sortable table" id="files-table">
-        <thead>
-        <tr>
-            <th>&nbsp;</th>
-            <th>Name</th>
-            <th>Priority</th>
-            <th>Bytes</th>
-            <th>Status</th>
-        </tr>
-        </thead>
-        <tbody>
-        <!--list_start files-->
-        <tr class="$statusclass_alt$">
-            <td><input class="selection" type="checkbox" name="$guid$" value="1" onclick="udctrls()"/></td>
-            <td>$name$</td>
-            <td>$priority$</td>
-            <td>$bytes$</td>
-            <td>$status$</td>
-        </tr>
-        <!--list_end-->
-        </tbody>
-    </table>
 
     <br/>
 </div>


### PR DESCRIPTION
It seems that the "files" table should be included in the form, as each file container has a unique GUID name assigned to it, so the changed settings cannot be applied since Tixati client doesn't know which exact file you're applying the changes to. This change fixed the issue for me and now I'm able to have the desired changes applied to the selected files.